### PR TITLE
Extend field `service` with several sub-fields

### DIFF
--- a/InterceptorCdr.go
+++ b/InterceptorCdr.go
@@ -17,13 +17,19 @@ import (
 //
 // 	a := golax.NewApi()
 //
+// 	s := &model.Service{
+// 	    Name: "My service",
+// 	    Version: "7.3.0",
+// 	    Commit: "0f0710f",
+// 	}
+//
 // 	a.Root.
 // 	    Interceptor(InterceptorCdr2Log()).
-// 	    Interceptor(InterceptorCdr("invented-service")).
+// 	    Interceptor(InterceptorCdr(s)).
 // 	    Method("GET", func(c *golax.Context) {
 // 	        // Implement your API here
 // 	    })
-func InterceptorCdr(service string) *golax.Interceptor {
+func InterceptorCdr(service *model.Service) *golax.Interceptor {
 	return &golax.Interceptor{
 		Documentation: golax.Doc{
 			Name: "InterceptorCDR",
@@ -40,7 +46,11 @@ func InterceptorCdr(service string) *golax.Interceptor {
 				"consumer_id": "my-consumer-id",
 				"origin": "127.0.0.1",
 				"session_id": "",
-				"service": "invented-service",
+				"service": {
+					"name": "invented-service",
+					"version": "7.3.0",
+					"commit": "a587df8"
+				},
 				"entry_date": "2016-10-21T18:46:19.820423299+02:00",
 				"entry_timestamp": 1.4770683798204234e+09,
 				"elapsed_seconds": 1.621246337890625e-05,

--- a/InterceptorCdr2Channel_test.go
+++ b/InterceptorCdr2Channel_test.go
@@ -23,7 +23,7 @@ func Test_Cdr2channel(t *testing.T) {
 	a.Root.
 		Interceptor(cdrtest.InterceptorCdr2Memory()).
 		Interceptor(InterceptorCdr2Channel(cdrs)).
-		Interceptor(InterceptorCdr("invented-service")).
+		Interceptor(InterceptorCdr(&model.Service{Name: "invented-service"})).
 		Node("api").
 		Method("GET", func(c *golax.Context) {
 

--- a/InterceptorCdr_test.go
+++ b/InterceptorCdr_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/fulldump/apitest"
 	"github.com/fulldump/golax"
 
+	"github.com/smartdigits/gocdr/model"
 	"github.com/smartdigits/gocdr/testutils"
 )
 
@@ -22,12 +23,17 @@ func Test_Cdr(t *testing.T) {
 
 	cdrtest := testutils.NewTestCDR()
 
-	a := golax.NewApi()
+	service := &model.Service{
+		Name:    "invented-service",
+		Version: "7.3.0",
+		Commit:  "70bbda5",
+	}
 
+	a := golax.NewApi()
 	a.Root.
 		Interceptor(cdrtest.InterceptorCdr2Memory()).
 		Interceptor(InterceptorCdr2Log()).
-		Interceptor(InterceptorCdr("invented-service")).
+		Interceptor(InterceptorCdr(service)).
 		Node("{param1}").
 		Node("{param2}").
 		Node("test-node").
@@ -58,8 +64,20 @@ func Test_Cdr(t *testing.T) {
 		t.Error("consumerID")
 	}
 
-	if "invented-service" != cdr.Service {
+	if nil == cdr.Service {
 		t.Error("service")
+	}
+
+	if "invented-service" != cdr.Service.Name {
+		t.Error("service.name")
+	}
+
+	if "7.3.0" != cdr.Service.Version {
+		t.Error("service.version")
+	}
+
+	if "70bbda5" != cdr.Service.Commit {
+		t.Error("service.commit")
 	}
 
 	if method != cdr.Request.Method {

--- a/constants/constants.go
+++ b/constants/constants.go
@@ -1,7 +1,7 @@
 package constants
 
 // VERSION is the model spec version for the CDR
-const VERSION = "1.0.0"
+const VERSION = "2.0.0"
 
 // CONTEXT_KEY is the key used to attach the CDR to the golax context. This
 // should be transparent to the user of this library.

--- a/model/cdr.go
+++ b/model/cdr.go
@@ -23,8 +23,8 @@ type CDR struct {
 	// SessionId stores cookie session, in case the client was using a session.
 	SessionId string `json:"session_id" bson:"session_id"`
 
-	// Service indicates the service/server name being provided.
-	Service string `json:"service" bson:"service"`
+	// Service indicates the service/server being provided.
+	Service *Service `json:"service" bson:"service"`
 
 	// EntryDate stores a `Time` object with the starting request timestamp.
 	EntryDate time.Time `json:"entry_date" bson:"entry_date"`

--- a/model/service.go
+++ b/model/service.go
@@ -1,0 +1,15 @@
+package model
+
+// Service identifies the process and other information related to the service.
+type Service struct {
+
+	// Name is the service name.
+	Name string `json:"name" bson:"name"`
+
+	// Version is the service version, for example: 1.2, 0.0.1, 7.3.
+	Version string `json:"version" bson:"version"`
+
+	// Commit is the short commit number to identify exactly the code base
+	// that is being executed
+	Commit string `json:"commit" bson:"commit"`
+}

--- a/testutils/interceptor_cdr2memory_test.go
+++ b/testutils/interceptor_cdr2memory_test.go
@@ -20,7 +20,7 @@ func Test_Cdr2memory(t *testing.T) {
 	a.Root.
 		Interceptor(cdrtest.InterceptorCdr2Memory()).
 		Interceptor(gocdr.InterceptorCdr2Log()).
-		Interceptor(gocdr.InterceptorCdr("invented-service")).
+		Interceptor(gocdr.InterceptorCdr(nil)).
 		Node("api").
 		Method("GET", func(c *golax.Context) {
 

--- a/utils/chan2mongo.go
+++ b/utils/chan2mongo.go
@@ -58,7 +58,7 @@ func Chan2Mongo(s chan *model.CDR, m *mgo.Database) {
 // GetCollectionName generates the name for the collection to split CDR
 // across timestamp
 func GetCollectionName(cdr *model.CDR) string {
-	return "cdr"
+	return "cdrs"
 	// return fmt.Sprintf(
 	// 	"cdr%04d%02d%02d",
 	// 	cdr.EntryDate.Year(),

--- a/utils/chan2mongo_test.go
+++ b/utils/chan2mongo_test.go
@@ -42,7 +42,7 @@ func Test_Chan2Mongo(t *testing.T) {
 	a.Root.
 		Interceptor(cdrtest.InterceptorCdr2Memory()).
 		Interceptor(gocdr.InterceptorCdr2Channel(cdrs)). // #3 put CDRs in channel
-		Interceptor(gocdr.InterceptorCdr("invented-service")).
+		Interceptor(gocdr.InterceptorCdr(nil)).
 		Node("api").
 		Method("GET", func(c *golax.Context) {})
 


### PR DESCRIPTION
New struct for field `Service`:

```golang
// Service identifies the process and other information related to the service.
type Service struct {

	// Name is the service name.
	Name string `json:"name" bson:"name"`

	// Version is the service version, for example: 1.2, 0.0.1, 7.3.
	Version string `json:"version" bson:"version"`

	// Commit is the short commit number to identify exactly the code base
	// that is being executed
	Commit string `json:"commit" bson:"commit"`
}
```

This feature is breaking backwards compat. The model changes and the instantiation changes. So the new CDR version has been bumped to 2.0.0.